### PR TITLE
TTFT : Staged Encoder (E) & PD Timing with Socket Reporting and Proxy Aggregation

### DIFF
--- a/examples/online_serving/epd/proxy.py
+++ b/examples/online_serving/epd/proxy.py
@@ -167,7 +167,7 @@ async def chat_completions(request: Request):
         ingress_wall_ns = time.time_ns()
         request_id = request.headers.get("x-request-id")
         try:
-            meta_entry = app.state.ttft_store.get(request_id)
+            meta_entry = app.state.ttft_store.get(request_id, None)
             if meta_entry is None:
                 meta_entry = TTFTStoreEntry()
                 app.state.ttft_store[request_id] = meta_entry
@@ -317,6 +317,7 @@ class TTFTPartial:
 class TTFTStoreEntry:
     encoder: TTFTPartial = field(default_factory=TTFTPartial)
     pd: TTFTPartial = field(default_factory=TTFTPartial)
+    meta: TTFTPartial = field(default_factory=TTFTPartial)
     ts_last_update: float = field(default_factory=lambda: time.time())
 
     def merge(self, role: str, payload: dict):
@@ -376,6 +377,7 @@ async def ttft_get(request_id: str):
     return {
         "request_id": request_id,
         "by_role": {
+            "meta": entry.meta.as_dict(),
             "encoder": entry.encoder.as_dict(),
             "pd": entry.pd.as_dict(),
         },

--- a/examples/online_serving/epd/proxy.py
+++ b/examples/online_serving/epd/proxy.py
@@ -165,7 +165,8 @@ async def chat_completions(request: Request):
     """Handle chat completion requests."""
     try:
         ingress_wall_ns = time.time_ns()
-        request_id = request.headers.get("x-request-id")
+        raw_id = request.headers.get("x-request-id")
+        request_id = raw_id if raw_id else str(uuid.uuid4())
         rid = request_id
         if rid.startswith("chatcmpl-"):
             rid = rid[len("chatcmpl-"):]
@@ -377,11 +378,11 @@ async def ttft_report(request: Request):
     combined = entry.combined().as_dict()
     result = {
         "request_id": cano,
-        "combined": combined,
+        "combined": combined
     }
     if is_complete(result):
-        logger.info("TTFT report update for %s: %s", cano, result)
-    return JSONResponse(content=result)
+        logger.info("[TTFT] report update for %s: %s", cano, result)
+    return JSONResponse(result)
 
 @app.get("/ttft_report/{request_id}")
 async def ttft_get(request_id: str):

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -103,22 +103,19 @@ def _parse(u: str):
 HOST, PORT, PATH = _parse(_URL)
 
 def send_ttft_report(payload: dict) -> None:
-    # 调用入口
-    print(f"[TTFT][REPORTER_CALL] host={HOST} port={PORT} path={PATH} payload={payload}", flush=True)
-
     if HOST is None:
         return
     if not payload or "request_id" not in payload:
         return
 
-    # 序列化
+    # serialize
     try:
         body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
     except Exception as e:
         print(f"[TTFT][SERIALIZE_FAIL] {e} payload={payload}", file=sys.stderr, flush=True)
         return
 
-    # 连接
+    # socket connect
     t0 = time.perf_counter()
     try:
         sock = socket.create_connection((HOST, PORT), timeout=0.2)
@@ -127,7 +124,7 @@ def send_ttft_report(payload: dict) -> None:
         return
     t_conn = (time.perf_counter() - t0) * 1000
 
-    # 发送
+    # send request
     try:
         req = (
             f"POST {PATH} HTTP/1.1\r\n"
@@ -147,7 +144,7 @@ def send_ttft_report(payload: dict) -> None:
             pass
         return
 
-    # 直接关闭（不读响应）
+    # close socket without reading response
     try:
         sock.close()
     except:

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -89,7 +89,7 @@ def _parse(u: str):
     assert u.startswith("http://")
     rest = u[7:]
     if "/" in rest:
-        hostport, path = rest.split("/", 1)
+        host_port, path = rest.split("/", 1)
         path = "/" + path
     else:
         host_port, path = rest, "/"

--- a/vllm/model_executor/utils.py
+++ b/vllm/model_executor/utils.py
@@ -89,26 +89,18 @@ def _parse(u: str):
     assert u.startswith("http://")
     rest = u[7:]
     if "/" in rest:
-        hostport, p = rest.split("/", 1)
-        p = "/" + p
+        hostport, path = rest.split("/", 1)
+        path = "/" + path
     else:
-        hostport, p = rest, "/"
-    if ":" in hostport:
-        h, pt = hostport.split(":", 1)
-        try:
-            pt = int(pt)
-        except:
-            raise ValueError(f"bad port in URL {u}")
+        host_port, path = rest, "/"
+    if ":" in host_port:
+        host, port = host_port.split(":", 1)
+        port = int(port)
     else:
-        h, pt = hostport, 80
-    return h, pt, p
+        host, port = host_port, 80
+    return host, port, path
 
-try:
-    HOST, PORT, PATH = _parse(_URL)
-except Exception as e:
-    print(f"[TTFT][PARSE_ERR] {_URL} {e}", file=sys.stderr, flush=True)
-    HOST = PORT = PATH = None
-
+HOST, PORT, PATH = _parse(_URL)
 
 def send_ttft_report(payload: dict) -> None:
     # 调用入口

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -234,6 +234,7 @@ class Scheduler(SchedulerInterface):
 
             # Schedule encoder inputs.
             encoder_inputs_to_schedule = None
+            external_load_encoder_input = None
             new_encoder_budget = encoder_budget
             if request.has_encoder_inputs:
                 (encoder_inputs_to_schedule, num_new_tokens,
@@ -241,6 +242,50 @@ class Scheduler(SchedulerInterface):
                  ) = self._try_schedule_encoder_inputs(
                      request, request.num_computed_tokens, num_new_tokens,
                      encoder_budget)
+                # If need schedule encoder inputs: enc_queue_start
+                if request.request_id not in self._ttft_enc_queue_start and \
+                    encoder_inputs_to_schedule:
+                    self._ttft_enc_queue_start[request.request_id] = time.perf_counter()
+
+                # If need schedule encoder inputs and already start: enc_queue_end
+                if request.request_id in self._ttft_enc_queue_start and \
+                    request.request_id not in self._ttft_enc_queue_report and \
+                        encoder_inputs_to_schedule:
+                    t_start_queue = self._ttft_enc_queue_start[request.request_id]
+                    enc_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                    payload = {
+                        "role": "encoder",
+                        "request_id": request.request_id,
+                        "enc_queue_time_ms": enc_queue_ms,
+                    }
+                    try:
+                        send_ttft_report(payload)
+                    except Exception as e:
+                        pass
+                    self._ttft_enc_queue_report.add(request.request_id)
+                
+                # If no need schedule encoder inputs: prefill_queue_start
+                no_more_encoder_work = not encoder_inputs_to_schedule and not external_load_encoder_input
+                if no_more_encoder_work and request.request_id not in self._ttft_prefill_queue_start:
+                    self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
+            else:
+                if request.request_id not in self._ttft_prefill_queue_start:
+                    self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
+            # allocate num_new_tokens for this request for the first time
+            if request.request_id in self._ttft_prefill_queue_start:
+                if request.request_id not in self._ttft_prefill_queue_report and num_new_tokens > 0:
+                    t_start_queue = self._ttft_prefill_queue_start[request.request_id]
+                    prefill_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                    payload = {
+                        "role": "pd",
+                        "request_id": request.request_id,
+                        "prefill_queue_time_ms": prefill_queue_ms,
+                    }
+                    try:
+                        send_ttft_report(payload)
+                    except Exception as e:
+                        pass
+                    self._ttft_prefill_queue_report.add(request.request_id)
 
             if num_new_tokens == 0:
                 # The request cannot be scheduled because one of the following

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import time
+import os
 from collections import defaultdict, deque
 from collections.abc import Iterable
 from typing import Any, Optional, Union
@@ -170,10 +171,12 @@ class Scheduler(SchedulerInterface):
         )
 
         # TTFT
-        self._ttft_enc_queue_start: dict[str, float] = {}
-        self._ttft_enc_queue_report: set[str] = set()
-        self._ttft_prefill_queue_start: dict[str, float] = {}
-        self._ttft_prefill_queue_report: set[str] = set()
+        self.TTFT_ENABLED = os.environ.get("TTFT_ENABLED", "0")
+        if self.TTFT_ENABLED:
+            self._ttft_enc_queue_start: dict[str, float] = {}
+            self._ttft_enc_queue_report: set[str] = set()
+            self._ttft_prefill_queue_start: dict[str, float] = {}
+            self._ttft_prefill_queue_report: set[str] = set()
 
     def schedule(self) -> SchedulerOutput:
         # NOTE(woosuk) on the scheduling algorithm:
@@ -440,77 +443,79 @@ class Scheduler(SchedulerInterface):
                          ) = self._try_schedule_encoder_inputs(
                              request, num_computed_tokens, num_new_tokens,
                              encoder_budget)
-                        
-                        # If need schedule encoder inputs: enc_queue_start
-                        if request.request_id not in self._ttft_enc_queue_start and \
-                            encoder_inputs_to_schedule:
-                            self._ttft_enc_queue_start[request.request_id] = time.perf_counter()
-
-                        # If need schedule encoder inputs and already start: enc_queue_end
-                        if request.request_id in self._ttft_enc_queue_start and \
-                            request.request_id not in self._ttft_enc_queue_report and \
+                        if self.TTFT_ENABLED:
+                            # If need schedule encoder inputs: enc_queue_start
+                            if request.request_id not in self._ttft_enc_queue_start and \
                                 encoder_inputs_to_schedule:
-                            t_start_queue = self._ttft_enc_queue_start[request.request_id]
-                            enc_queue_ms = (time.perf_counter() - t_start_queue) * 1000
-                            rid = request.request_id
-                            if rid.startswith("chatcmpl-"):
-                                rid = rid[len("chatcmpl-"):]
-                            payload = {
-                                "role": "encoder",
-                                "request_id": rid,
-                                "enc_queue_time_ms": enc_queue_ms,
-                            }
-                            try:
-                                send_ttft_report(payload)
-                            except Exception as e:
-                                pass
-                            self._ttft_enc_queue_report.add(request.request_id)
-                        
-                        # If no need schedule encoder inputs: prefill_queue_start
-                        no_more_encoder_work = not encoder_inputs_to_schedule and not external_load_encoder_input
-                        if no_more_encoder_work and request.request_id not in self._ttft_prefill_queue_start:
-                            self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
+                                self._ttft_enc_queue_start[request.request_id] = time.perf_counter()
+
+                            # If need schedule encoder inputs and already start: enc_queue_end
+                            if request.request_id in self._ttft_enc_queue_start and \
+                                request.request_id not in self._ttft_enc_queue_report and \
+                                    encoder_inputs_to_schedule:
+                                t_start_queue = self._ttft_enc_queue_start[request.request_id]
+                                enc_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                                rid = request.request_id
+                                if rid.startswith("chatcmpl-"):
+                                    rid = rid[len("chatcmpl-"):]
+                                payload = {
+                                    "role": "encoder",
+                                    "request_id": rid,
+                                    "enc_queue_time_ms": enc_queue_ms,
+                                }
+                                try:
+                                    send_ttft_report(payload)
+                                except Exception as e:
+                                    pass
+                                self._ttft_enc_queue_report.add(request.request_id)
+                            
+                            # If no need schedule encoder inputs: prefill_queue_start
+                            no_more_encoder_work = not encoder_inputs_to_schedule and not external_load_encoder_input
+                            if no_more_encoder_work and request.request_id not in self._ttft_prefill_queue_start:
+                                self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
 
                         if num_new_tokens == 0:
                             # The request cannot be scheduled.
                             break
                     else:
-                        if request.request_id not in self._ttft_prefill_queue_start:
-                            self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
-                    # allocate num_new_tokens for this request for the first time
-                    if request.request_id in self._ttft_prefill_queue_start:
-                        if request.request_id not in self._ttft_prefill_queue_report and num_new_tokens > 0:
-                            t_start_queue = self._ttft_prefill_queue_start[request.request_id]
-                            prefill_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                        if self.TTFT_ENABLED:
+                            if request.request_id not in self._ttft_prefill_queue_start:
+                                self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
+                    if self.TTFT_ENABLED:
+                        # allocate num_new_tokens for this request for the first time
+                        if request.request_id in self._ttft_prefill_queue_start:
+                            if request.request_id not in self._ttft_prefill_queue_report and num_new_tokens > 0:
+                                t_start_queue = self._ttft_prefill_queue_start[request.request_id]
+                                prefill_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                                rid = request.request_id
+                                if rid.startswith("chatcmpl-"):
+                                    rid = rid[len("chatcmpl-"):]
+                                payload = {
+                                    "role": "pd",
+                                    "request_id": rid,
+                                    "prefill_queue_time_ms": prefill_queue_ms,
+                                }
+                                try:
+                                    send_ttft_report(payload)
+                                except Exception as e:
+                                    pass
+                                self._ttft_prefill_queue_report.add(request.request_id)
+                        elif num_new_tokens > 0 and request.request_id not in self._ttft_prefill_queue_report:
+                            # If need to process encoder and prefill at the same time
+                            # prefill_queue_time_ms = 0
                             rid = request.request_id
                             if rid.startswith("chatcmpl-"):
                                 rid = rid[len("chatcmpl-"):]
                             payload = {
                                 "role": "pd",
                                 "request_id": rid,
-                                "prefill_queue_time_ms": prefill_queue_ms,
+                                "prefill_queue_time_ms": 0.0,
                             }
                             try:
                                 send_ttft_report(payload)
-                            except Exception as e:
+                            except Exception:
                                 pass
                             self._ttft_prefill_queue_report.add(request.request_id)
-                    elif num_new_tokens > 0 and request.request_id not in self._ttft_prefill_queue_report:
-                        # If need to process encoder and prefill at the same time
-                        # prefill_queue_time_ms = 0
-                        rid = request.request_id
-                        if rid.startswith("chatcmpl-"):
-                            rid = rid[len("chatcmpl-"):]
-                        payload = {
-                            "role": "pd",
-                            "request_id": rid,
-                            "prefill_queue_time_ms": 0.0,
-                        }
-                        try:
-                            send_ttft_report(payload)
-                        except Exception:
-                            pass
-                        self._ttft_prefill_queue_report.add(request.request_id)
 
                 new_blocks = self.kv_cache_manager.allocate_slots(
                     request,

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -452,9 +452,12 @@ class Scheduler(SchedulerInterface):
                                 encoder_inputs_to_schedule:
                             t_start_queue = self._ttft_enc_queue_start[request.request_id]
                             enc_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                            rid = request.request_id
+                            if rid.startswith("chatcmpl-"):
+                                rid = rid[len("chatcmpl-"):]
                             payload = {
                                 "role": "encoder",
-                                "request_id": request.request_id,
+                                "request_id": rid,
                                 "enc_queue_time_ms": enc_queue_ms,
                             }
                             try:
@@ -479,9 +482,12 @@ class Scheduler(SchedulerInterface):
                         if request.request_id not in self._ttft_prefill_queue_report and num_new_tokens > 0:
                             t_start_queue = self._ttft_prefill_queue_start[request.request_id]
                             prefill_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                            rid = request.request_id
+                            if rid.startswith("chatcmpl-"):
+                                rid = rid[len("chatcmpl-"):]
                             payload = {
                                 "role": "pd",
-                                "request_id": request.request_id,
+                                "request_id": rid,
                                 "prefill_queue_time_ms": prefill_queue_ms,
                             }
                             try:
@@ -492,9 +498,12 @@ class Scheduler(SchedulerInterface):
                     elif num_new_tokens > 0 and request.request_id not in self._ttft_prefill_queue_report:
                         # If need to process encoder and prefill at the same time
                         # prefill_queue_time_ms = 0
+                        rid = request.request_id
+                        if rid.startswith("chatcmpl-"):
+                            rid = rid[len("chatcmpl-"):]
                         payload = {
                             "role": "pd",
-                            "request_id": request.request_id,
+                            "request_id": rid,
                             "prefill_queue_time_ms": 0.0,
                         }
                         try:

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -34,6 +34,7 @@ from vllm.v1.outputs import ModelRunnerOutput
 from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
+from vllm.model_executor.utils import send_ttft_report
 
 logger = init_logger(__name__)
 
@@ -411,6 +412,7 @@ class Scheduler(SchedulerInterface):
                     num_computed_tokens = request.num_computed_tokens
 
                 encoder_inputs_to_schedule = None
+                external_load_encoder_input = None
                 new_encoder_budget = encoder_budget
 
                 # KVTransfer: loading remote KV, do not allocate for new work.
@@ -437,30 +439,41 @@ class Scheduler(SchedulerInterface):
                          ) = self._try_schedule_encoder_inputs(
                              request, num_computed_tokens, num_new_tokens,
                              encoder_budget)
-                        if request.request_id not in self._ttft_enc_queue_start:
+                        
+                        # If need schedule encoder inputs: enc_queue_start
+                        if request.request_id not in self._ttft_enc_queue_start and \
+                            encoder_inputs_to_schedule:
                             self._ttft_enc_queue_start[request.request_id] = time.perf_counter()
-                        if num_new_tokens == 0:
+
+                        # If need schedule encoder inputs and already start: enc_queue_end
+                        if request.request_id in self._ttft_enc_queue_start and \
+                            request.request_id not in self._ttft_enc_queue_report and \
+                                encoder_inputs_to_schedule:
+                            t_start_queue = self._ttft_enc_queue_start[request.request_id]
+                            enc_queue_ms = (time.perf_counter() - t_start_queue) * 1000
+                            payload = {
+                                "role": "encoder",
+                                "request_id": request.request_id,
+                                "enc_queue_time_ms": enc_queue_ms,
+                            }
+                            try:
+                                send_ttft_report(payload)
+                            except Exception as e:
+                                pass
+                            self._ttft_enc_queue_report.add(request.request_id)
+                        
+                        # If no need schedule encoder inputs: prefill_queue_start
+                        no_more_encoder_work = not encoder_inputs_to_schedule and not external_load_encoder_input
+                        if no_more_encoder_work and request.request_id not in self._ttft_prefill_queue_start:
                             self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
+
+                        if num_new_tokens == 0:
                             # The request cannot be scheduled.
                             break
-                        
-                        if request.request_id in self._ttft_enc_queue_start:
-                            if request.request_id not in self._ttft_enc_queue_report and encoder_inputs_to_schedule:
-                                t_start_queue = self._ttft_enc_queue_start[request.request_id]
-                                enc_queue_ms = (time.perf_counter() - t_start_queue) * 1000
-                                payload = {
-                                    "role": "encoder",
-                                    "request_id": request.request_id,
-                                    "encoder_queue_time_ms": enc_queue_ms,
-                                }
-                                try:
-                                    send_ttft_report(payload)
-                                except Exception as e:
-                                    pass
-                                self._ttft_enc_queue_report.add(request.request_id)
                     else:
                         if request.request_id not in self._ttft_prefill_queue_start:
                             self._ttft_prefill_queue_start[request.request_id] = time.perf_counter()
+                    # allocate num_new_tokens for this request for the first time
                     if request.request_id in self._ttft_prefill_queue_start:
                         if request.request_id not in self._ttft_prefill_queue_report and num_new_tokens > 0:
                             t_start_queue = self._ttft_prefill_queue_start[request.request_id]


### PR DESCRIPTION
<!-- markdownlint-disable -->
PLEASE FILL IN THE PR DESCRIPTION HERE ENSURING ALL CHECKLIST ITEMS (AT THE BOTTOM) HAVE BEEN CONSIDERED.

## Purpose
This PR adds an optional Time‑to‑First‑Token (TTFT) pipeline. When enabled, the Encoder (E) and Prefill/Decode (PD) components timestamp key latency stages and asynchronously report them to the proxy, which merges per‑request partials.

**Environment Variables**

TTFT_ENABLED=1 (default off). When not set or 0, no overhead or network traffic.
VLLM_TTFT_REPORT_URL=http://<host>:<port>/ttft_report Target HTTP endpoint (proxy). If unset and TTFT disabled → no effect; if unset but enabled → falls back to http://127.0.0.1:28886/ttft_report (can be documented / adjusted).

**Collected Stage Metrics (all ms):**

enc_queue_time_ms
enc_compute_time_ms
emb_cache_transfer_time_ms (optional)
prefill_queue_time_ms
prefill_compute_time_ms
Derived when all present: ttft_ms = sum(stage_times).

**Transport**

Each stage is emitted exactly once as a tiny JSON payload:
{"role":"meta|encoder|pd","request_id":"<uuid>","<metric_name>":<value>}
Sent via fire‑and‑forget TCP socket (raw HTTP/1.1 POST, no response wait) to minimize tail latency impact; failures are silently dropped.

**Proxy Aggregation**

Proxy keeps an in‑memory map keyed by request_id, merges first‑write values, and (optionally) logs only on new stage arrival or completion. Query: GET /ttft_report/<request_id> returns merged by_role + combined.

**Usage**

Set TTFT_ENABLED=1 and VLLM_TTFT_REPORT_URL.
Start services (E, PD, proxy).
Inspect /ttft_report/<request_id> for structured TTFT breakdown.
## Test Plan

<details>
#!/usr/bin/env bash
set -euo pipefail

wait_for_server() {
    local port=$1
    timeout 12000 bash -c '
        until curl -s "http://localhost:'"$port"'/v1/chat/completions" > /dev/null; do
            sleep 1
        done
    ' && return 0 || return 1
}

export VLLM_USE_V1=1

LOG_PATH=${LOG_PATH:-./logs}
mkdir -p "$LOG_PATH"

ENCODE_PORT=19534
PREFILL_DECODE_PORT=19535
PROXY_PORT=28886

GPU_E=4
GPU_PD=5

START_TIME=$(date +"%Y%m%d_%H%M%S")
ENC_LOG="$LOG_PATH/encoder.log"
PD_LOG="$LOG_PATH/pd.log"
PROXY_LOG="$LOG_PATH/proxy.log"
PID_FILE="./pid.txt"

SHARED_STORAGE_PATH="/workspace/l00807937/EPD_count/vllm-LJH-for-jiaofu/examples/online_serving/epd/storage"
export VLLM_TTFT_REPORT_URL=http://127.0.0.1:${PROXY_PORT}/ttft_report
export TTFT_ENABLED=True

export VLLM_HTTP_TIMEOUT_KEEP_ALIVE="${VLLM_HTTP_TIMEOUT_KEEP_ALIVE:-70}"
export CLIENT_HTTP_TIMEOUT_KEEP_ALIVE="${CLIENT_HTTP_TIMEOUT_KEEP_ALIVE:-60}"

if (( $CLIENT_HTTP_TIMEOUT_KEEP_ALIVE >= $VLLM_HTTP_TIMEOUT_KEEP_ALIVE )); then
    echo "Error: Client keep alive timeout ($CLIENT_HTTP_TIMEOUT_KEEP_ALIVE) should be" \
    " < server keep alive timeout ($VLLM_HTTP_TIMEOUT_KEEP_ALIVE)."
    exit 1
fi

ASCEND_RT_VISIBLE_DEVICES="$GPU_E" vllm serve  "/workspace/models/Qwen2.5-VL-7B-Instruct" \
    --gpu-memory-utilization 0.0 \
    --port "$ENCODE_PORT" \
    --enable-request-id-headers \
    --no-enable-prefix-caching \
    --max-num-seqs 4 \
    --max-model-len 4096  \
    --max-num-batched-tokens 4096 \
    --enforce-eager \
    --allowed-local-media-path /workspace/l00807937/ \
    --ec-transfer-config '{
        "ec_connector": "ECSharedStorageConnector",
        "ec_role": "ec_producer",
        "ec_connector_extra_config": {
            "shared_storage_path": "'"$SHARED_STORAGE_PATH"'",
            "ec_max_num_scheduled_tokens": "4096"
        }
    }' \
    >"$ENC_LOG" 2>&1 &

echo $! >> "$PID_FILE"

ASCEND_RT_VISIBLE_DEVICES="$GPU_PD" vllm serve "/workspace/models/Qwen2.5-VL-7B-Instruct" \
    --gpu-memory-utilization 0.9 \
    --port "$PREFILL_DECODE_PORT" \
    --enable-request-id-headers \
    --max-num-seqs 128 \
    --enforce-eager \
    --max-model-len 4096  \
    --max-num-batched-tokens 4096 \
    --allowed-local-media-path /workspace/l00807937/ \
    --ec-transfer-config '{
        "ec_connector": "ECSharedStorageConnector",
        "ec_role": "ec_consumer",
        "ec_connector_extra_config": {
            "shared_storage_path": "'"$SHARED_STORAGE_PATH"'"
        }
    }' \
    >"$PD_LOG" 2>&1 &

echo $! >> "$PID_FILE"

wait_for_server "$ENCODE_PORT"
wait_for_server "$PREFILL_DECODE_PORT"

python /workspace/l00807937/EPD_count/vllm-LJH-for-jiaofu/examples/online_serving/epd/proxy.py \
    --host "127.0.0.1" \
    --port "$PROXY_PORT" \
    --encode-servers-urls "http://localhost:$ENCODE_PORT" \
    --prefill-decode-servers-urls "http://localhost:$PREFILL_DECODE_PORT" \
    >"$PROXY_LOG" 2>&1 &

echo $! >> "$PID_FILE"

echo "All services are up!"
</details>

## Test Result

INFO:__main__:[TTFT] report update for 3a8713d1-494c-4ec2-8848-672b4571b72d: {'request_id': '3a8713d1-494c-4ec2-8848-672b4571b72d', 'combined': {'enc_queue_time_ms': 0.002739951014518738, 'enc_compute_time_ms': 1002.8023803606629, 'emb_cache_transfer_time_ms': 2.2039590403437614, 'prefill_queue_time_ms': 0.0, 'prefill_compute_time_ms': 207.5677178800106, 't_request_ingress_ns': None, 'enc_ingress_wait_ms': None, 'ttft_ms': 1212.5767972320318}}
INFO:__main__:[TTFT] report update for 15879f51-130d-4250-9771-1d8389ae3fd3: {'request_id': '15879f51-130d-4250-9771-1d8389ae3fd3', 'combined': {'enc_queue_time_ms': 0.0034300610423088074, 'enc_compute_time_ms': 56.724236346781254, 'emb_cache_transfer_time_ms': 1.6047926619648933, 'prefill_queue_time_ms': 0.0, 'prefill_compute_time_ms': 28.90088688582182, 't_request_ingress_ns': None, 'enc_ingress_wait_ms': None, 'ttft_ms': 87.23334595561028}}

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

**BEFORE SUBMITTING, PLEASE READ <https://docs.vllm.ai/en/latest/contributing>** (anything written below this line will be removed by GitHub Actions)
