### PR TITLE
[Bug Fix] oom: pd repeate to compute mm encoder

### DIFF
--- a/vllm/distributed/ec_transfer/ec_connector/base.py
+++ b/vllm/distributed/ec_transfer/ec_connector/base.py
@@ -135,6 +135,17 @@ class ECConnectorBase(ABC):
         pass
 
     @abstractmethod
+    def clean_caches(self, request: "Request") -> None:
+        """
+        clean caches in ec_consumer side when request is finish.
+
+        Args:
+            request: Request
+
+        """
+        pass
+
+    @abstractmethod
     def save_caches(self, **kwargs) -> None:
         """
         Save caches into connector

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -835,6 +835,8 @@ class Scheduler(SchedulerInterface):
                 if stopped:
                     kv_transfer_params = self._free_request(request)
                     del new_token_ids[num_new:]  # Trim new tokens if needed.
+                    if self.ec_connector is not None:
+                        self.ec_connector.clean_caches(request)
                     break
 
             # Extract sample logprobs if needed.


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
The oom reason is that: PD execute the mm encoder, that should be never happend!
And the PD execute the mm encoder reason is that: the pd rm embedding file while loading it； in a preemption case, pd will read embedding again, and can't find it; it final schedule to do the mm encoder.

To solve it, we move the "rm embedding file" when the request finish

## Test Plan
1. 34B test batch size [96,112,128,192,256]
2. qwen test
## Test Result
1. all batch size is **success** and no oom
╒══════════════════════════╤═════════╤════════════════╤════════════════╤═════════════════╤════════════════╤════════════════╤═══════════════╤════════════════╤══════╕
│ Performance Parameters   │ Stage   │ Average        │ Min            │ Max             │ Median         │ P75            │ P90           │ P99            │  N   │
╞══════════════════════════╪═════════╪════════════════╪════════════════╪═════════════════╪════════════════╪════════════════╪═══════════════╪════════════════╪══════╡
│ E2EL                     │ total   │ 87081.0643 ms  │ 17331.8295 ms  │ 116180.0643 ms  │ 90251.0195 ms  │ 93410.6921 ms  │ 96677.2272 ms │ 105818.9129 ms │ 2000 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼─────────────────┼────────────────┼────────────────┼───────────────┼────────────────┼──────┤
│ TTFT                     │ total   │ 70862.3498 ms  │ 2884.7339 ms   │ 98237.5088 ms   │ 74031.3004 ms  │ 76976.3337 ms  │ 80021.4376 ms │ 88550.845 ms   │ 2000 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼─────────────────┼────────────────┼────────────────┼───────────────┼────────────────┼──────┤
│ TPOT                     │ total   │ 74.0581 ms     │ 57.5142 ms     │ 91.0499 ms      │ 74.0528 ms     │ 79.308 ms      │ 83.0078 ms    │ 87.8255 ms     │ 2000 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼─────────────────┼────────────────┼────────────────┼───────────────┼────────────────┼──────┤
│ ITL                      │ total   │ 89.613 ms      │ 0.0209 ms      │ 1489.3589 ms    │ 58.504 ms      │ 66.8776 ms     │ 186.9152 ms   │ 457.1931 ms    │ 2000 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼─────────────────┼────────────────┼────────────────┼───────────────┼────────────────┼──────┤
│ InputTokens              │ total   │ 289.7975       │ 150.0          │ 539.0           │ 281.0          │ 281.0          │ 539.0         │ 539.0          │ 2000 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼─────────────────┼────────────────┼────────────────┼───────────────┼────────────────┼──────┤
│ OutputTokens             │ total   │ 220.0          │ 220.0          │ 220.0           │ 220.0          │ 220.0          │ 220.0         │ 220.0          │ 2000 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼─────────────────┼────────────────┼────────────────┼───────────────┼────────────────┼──────┤
│ OutputTokenThroughput    │ total   │ 2.7184 token/s │ 1.8936 token/s │ 12.6934 token/s │ 2.4376 token/s │ 2.5323 token/s │ 2.707 token/s │ 9.7571 token/s │ 2000 │
╘══════════════════════════╧═════════╧════════════════╧════════════════╧═════════════════╧════════════════╧════════════════╧═══════════════╧════════════════╧══════╛
╒══════════════════════════╤═════════╤══════════════════╕
│ Common Metric            │ Stage   │ Value            │
╞══════════════════════════╪═════════╪══════════════════╡
│ Benchmark Duration       │ total   │ 719446.326 ms    │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Requests           │ total   │ 2000             │
├──────────────────────────┼─────────┼──────────────────┤
│ Failed Requests          │ total   │ 0                │
├──────────────────────────┼─────────┼──────────────────┤
│ Success Requests         │ total   │ 2000             │
├──────────────────────────┼─────────┼──────────────────┤
│ Concurrency              │ total   │ 242.078          │
├──────────────────────────┼─────────┼──────────────────┤
│ Max Concurrency          │ total   │ 256              │
├──────────────────────────┼─────────┼──────────────────┤
│ Request Throughput       │ total   │ 2.7799 req/s     │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Input Tokens       │ total   │ 579595           │
├──────────────────────────┼─────────┼──────────────────┤
│ Prefill Token Throughput │ total   │ 4.0896 token/s   │
├──────────────────────────┼─────────┼──────────────────┤
│ Total generated tokens   │ total   │ 440000           │
├──────────────────────────┼─────────┼──────────────────┤
│ Input Token Throughput   │ total   │ 805.6126 token/s │
├──────────────────────────┼─────────┼──────────────────┤
│ Output Token Throughput  │ total   │ 611.5814 token/s │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Token Throughput   │ total   │ 1417.194 token/s │
╘══════════════════════════╧═════════╧══════════════════╛
2. qwen request with no picture
<img width="1904" height="87" alt="image" src="https://github.com/user-attachments/assets/d52fca8a-a151-4afd-bba0-bf837f0791f1" />

3. qwen benchmark
--- baseline 
<img width="1174" height="643" alt="image" src="https://github.com/user-attachments/assets/e38c5fc7-3e32-4b0f-98c4-bf291aebee8e" />

--- now
<img width="1175" height="645" alt="image" src="https://github.com/user-attachments/assets/d1b5f35b-5695-4887-a6fb-5c5f7346fe06" />

no embedding file left
<img width="735" height="62" alt="image" src="https://github.com/user-attachments/assets/9d3694ba-683c-4d06-9e85-f720231a8dee" />


---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [x] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [x] The test plan, such as providing test command.
- [x] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

