### PR TITLE
[Bugfix][cherry-pick] "Can not write request body for"

### DIFF
--- a/examples/online_serving/disaggregated_encoder/disagg_1e1p1d_example.sh
+++ b/examples/online_serving/disaggregated_encoder/disagg_1e1p1d_example.sh
@@ -28,6 +28,18 @@ export UCX_TLS=all
 export UCX_NET_DEVICES=all
 
 ###############################################################################
+# Check env
+###############################################################################
+export VLLM_HTTP_TIMEOUT_KEEP_ALIVE="${VLLM_HTTP_TIMEOUT_KEEP_ALIVE:-70}"
+export CLIENT_HTTP_TIMEOUT_KEEP_ALIVE="${CLIENT_HTTP_TIMEOUT_KEEP_ALIVE:-60}"
+
+if (( $CLIENT_HTTP_TIMEOUT_KEEP_ALIVE >= $VLLM_HTTP_TIMEOUT_KEEP_ALIVE )); then
+    echo "Error: Client keep alive timeout ($CLIENT_HTTP_TIMEOUT_KEEP_ALIVE) should be" \
+    " < server keep alive timeout ($VLLM_HTTP_TIMEOUT_KEEP_ALIVE)."
+    exit 1
+fi
+
+###############################################################################
 # Helpers
 ###############################################################################
 START_TIME=$(date +"%Y%m%d_%H%M%S")

--- a/examples/online_serving/disaggregated_encoder/disagg_1e1pd_example.sh
+++ b/examples/online_serving/disaggregated_encoder/disagg_1e1pd_example.sh
@@ -23,6 +23,18 @@ TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-12000}"   # wait_for_server timeout
 NUM_PROMPTS="${NUM_PROMPTS:-100}"    # number of prompts to send in benchmark
 
 ###############################################################################
+# Check env
+###############################################################################
+export VLLM_HTTP_TIMEOUT_KEEP_ALIVE="${VLLM_HTTP_TIMEOUT_KEEP_ALIVE:-70}"
+export CLIENT_HTTP_TIMEOUT_KEEP_ALIVE="${CLIENT_HTTP_TIMEOUT_KEEP_ALIVE:-60}"
+
+if (( $CLIENT_HTTP_TIMEOUT_KEEP_ALIVE >= $VLLM_HTTP_TIMEOUT_KEEP_ALIVE )); then
+    echo "Error: Client keep alive timeout ($CLIENT_HTTP_TIMEOUT_KEEP_ALIVE) should be" \
+    " < server keep alive timeout ($VLLM_HTTP_TIMEOUT_KEEP_ALIVE)."
+    exit 1
+fi
+
+###############################################################################
 # Helpers
 ###############################################################################
 START_TIME=$(date +"%Y%m%d_%H%M%S")

--- a/examples/online_serving/disaggregated_encoder/disagg_epd_proxy.py
+++ b/examples/online_serving/disaggregated_encoder/disagg_epd_proxy.py
@@ -227,7 +227,10 @@ async def process_prefill_stage(
 async def on_startup() -> None:
     global encode_session, prefill_session, decode_session
     timeout = aiohttp.ClientTimeout(total=100_000)
-    connector = aiohttp.TCPConnector(limit=0, force_close=False)
+    keepalive_timeout = int(os.getenv("CLIENT_HTTP_TIMEOUT_KEEP_ALIVE", 0))
+    connector = aiohttp.TCPConnector(
+        limit=0, force_close=False, keepalive_timeout=keepalive_timeout
+    )
     encode_session = aiohttp.ClientSession(timeout=timeout, connector=connector)
     if app.state.p_urls:
         # only setup if prefill instance(s) exist

--- a/examples/online_serving/disaggregated_encoder/mooncake_connector/disagg_1e1pd_example.sh
+++ b/examples/online_serving/disaggregated_encoder/mooncake_connector/disagg_1e1pd_example.sh
@@ -34,6 +34,18 @@ SCRIPT_PATH="$(readlink -f "$0")"
 SCRIPT_DIR="$(dirname "$SCRIPT_PATH")"
 
 ###############################################################################
+# Check env
+###############################################################################
+export VLLM_HTTP_TIMEOUT_KEEP_ALIVE="${VLLM_HTTP_TIMEOUT_KEEP_ALIVE:-70}"
+export CLIENT_HTTP_TIMEOUT_KEEP_ALIVE="${CLIENT_HTTP_TIMEOUT_KEEP_ALIVE:-60}"
+
+if (( $CLIENT_HTTP_TIMEOUT_KEEP_ALIVE >= $VLLM_HTTP_TIMEOUT_KEEP_ALIVE )); then
+    echo "Error: Client keep alive timeout ($CLIENT_HTTP_TIMEOUT_KEEP_ALIVE) should be" \
+    " < server keep alive timeout ($VLLM_HTTP_TIMEOUT_KEEP_ALIVE)."
+    exit 1
+fi
+
+###############################################################################
 # Helpers
 ###############################################################################
 START_TIME=$(date +"%Y%m%d_%H%M%S")


### PR DESCRIPTION
## Purpose
Change the client's keep alive timeout less than server's，so it can avoid client reuse a http connection that close by vllm
## Test Plan

## Test Result
╒══════════════════════════╤═════════╤════════════════╤═══════════════╤════════════════╤════════════════╤════════════════╤════════════════╤════════════════╤═════╕
│ Performance Parameters   │ Stage   │ Average        │ Min           │ Max            │ Median         │ P75            │ P90            │ P99            │  N  │
╞══════════════════════════╪═════════╪════════════════╪═══════════════╪════════════════╪════════════════╪════════════════╪════════════════╪════════════════╪═════╡
│ E2EL                     │ total   │ 482800.0451 ms │ 54636.6442 ms │ 806209.4393 ms │ 481933.2085 ms │ 664986.6582 ms │ 751931.0804 ms │ 806106.0019 ms │ 100 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TTFT                     │ total   │ 410874.0031 ms │ 24626.1998 ms │ 751619.0858 ms │ 417335.1872 ms │ 577974.9866 ms │ 687536.1418 ms │ 743642.3517 ms │ 100 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TPOT                     │ total   │ 3499.4545 ms   │ 62.1373 ms    │ 5384.0211 ms   │ 3568.3493 ms   │ 3733.7182 ms   │ 3853.61 ms     │ 5155.7749 ms   │ 100 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ ITL                      │ total   │ 2962.31 ms     │ 0.0111 ms     │ 6840.9194 ms   │ 3467.5271 ms   │ 3729.8848 ms   │ 3908.4474 ms   │ 4467.7181 ms   │ 100 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ InputTokens              │ total   │ 76.0           │ 76.0          │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 100 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokens             │ total   │ 23.28          │ 3.0           │ 126.0          │ 13.0           │ 15.0           │ 74.0           │ 124.02         │ 100 │
├──────────────────────────┼─────────┼────────────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokenThroughput    │ total   │ 0.0484 token/s │ 0.004 token/s │ 0.2319 token/s │ 0.0224 token/s │ 0.0849 token/s │ 0.128 token/s  │ 0.187 token/s  │ 100 │
╘══════════════════════════╧═════════╧════════════════╧═══════════════╧════════════════╧════════════════╧════════════════╧════════════════╧════════════════╧═════╛
╒══════════════════════════╤═════════╤════════════════╕
│ Common Metric            │ Stage   │ Value          │
╞══════════════════════════╪═════════╪════════════════╡
│ Benchmark Duration       │ total   │ 954523.8851 ms │
├──────────────────────────┼─────────┼────────────────┤
│ Total Requests           │ total   │ 100            │
├──────────────────────────┼─────────┼────────────────┤
│ Failed Requests          │ total   │ 0              │
├──────────────────────────┼─────────┼────────────────┤
│ Success Requests         │ total   │ 100            │
├──────────────────────────┼─────────┼────────────────┤
│ Concurrency              │ total   │ 50.5802        │
├──────────────────────────┼─────────┼────────────────┤
│ Max Concurrency          │ total   │ 128            │
├──────────────────────────┼─────────┼────────────────┤
│ Request Throughput       │ total   │ 0.1048 req/s   │
├──────────────────────────┼─────────┼────────────────┤
│ Total Input Tokens       │ total   │ 7600           │
├──────────────────────────┼─────────┼────────────────┤
│ Prefill Token Throughput │ total   │ 0.185 token/s  │
├──────────────────────────┼─────────┼────────────────┤
│ Total generated tokens   │ total   │ 2328           │
├──────────────────────────┼─────────┼────────────────┤
│ Input Token Throughput   │ total   │ 7.9621 token/s │
├──────────────────────────┼─────────┼────────────────┤
│ Output Token Throughput  │ total   │ 2.4389 token/s │
├──────────────────────────┼─────────┼────────────────┤
│ Total Token Throughput   │ total   │ 10.401 token/s │
╘══════════════════════════╧═════════╧════════════════╛

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

