### PR TITLE
[BugFix] no load weight in tarsier

### DIFF
--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -15,6 +15,7 @@ import vllm.envs as envs
 from vllm.config import VllmConfig
 from vllm.distributed import (get_tensor_model_parallel_rank,
                               get_tensor_model_parallel_world_size)
+from vllm.distributed.ec_transfer import get_ec_transfer, has_ec_transfer
 from vllm.logger import init_logger
 from vllm.model_executor.model_loader.weight_utils import default_weight_loader
 from vllm.multimodal import NestedTensors
@@ -288,8 +289,13 @@ class AutoWeightsLoader:
         if mapper is not None:
             weights = mapper.apply(weights)
         # filter out weights with first-prefix/substr to skip in name
-        weights = ((name, weight) for name, weight in weights
-                   if not self._can_skip(name))
+        if has_ec_transfer() and get_ec_transfer().is_producer:
+            weights = ((name, weight) for name, weight in weights
+                       if not self._can_skip(name)
+                       and not name.startswith("language_model.model.layers"))
+        else:
+            weights = ((name, weight) for name, weight in weights
+                       if not self._can_skip(name))
 
         autoloaded_weights = set(self._load_module("", self.module, weights))
         return autoloaded_weights


### PR DESCRIPTION

## Purpose
Skip weight load in a simple way
## Test Plan
check npu usage:
```
+------------------------------------------------------------------------------------------------+
| npu-smi 24.1.rc2                 Version: 24.1.rc2                                             |
+---------------------------+---------------+----------------------------------------------------+
| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
| Chip                      | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
+===========================+===============+====================================================+
| 0     910B4               | OK            | 88.4        34                0    / 0             |
| 0                         | 0000:C1:00.0  | 0           0    / 0          5646 / 32768         |
+===========================+===============+====================================================+
| 1     910B4               | OK            | 87.5        36                0    / 0             |
| 0                         | 0000:01:00.0  | 0           0    / 0          28994/ 32768         |
+===========================+===============+====================================================+
| 2     910B4               | OK            | 89.6        37                0    / 0             |
| 0                         | 0000:C2:00.0  | 0           0    / 0          28997/ 32768         |
+===========================+===============+====================================================+
| 3     910B4               | OK            | 89.5        36                0    / 0             |
| 0                         | 0000:02:00.0  | 0           0    / 0          2857 / 32768         |
+===========================+===============+====================================================+
| 4     910B4               | OK            | 86.0        34                0    / 0             |
| 0                         | 0000:81:00.0  | 0           0    / 0          2846 / 32768         |
+===========================+===============+====================================================+
| 5     910B4               | OK            | 94.7        36                0    / 0             |
| 0                         | 0000:41:00.0  | 0           0    / 0          2840 / 32768         |
+===========================+===============+====================================================+
| 6     910B4               | OK            | 85.4        34                0    / 0             |
| 0                         | 0000:82:00.0  | 0           0    / 0          2853 / 32768         |
+===========================+===============+====================================================+
| 7     910B4               | OK            | 86.2        37                0    / 0             |
| 0                         | 0000:42:00.0  | 0           0    / 0          2855 / 32768         |
+===========================+===============+====================================================+
+---------------------------+---------------+----------------------------------------------------+
| NPU     Chip              | Process id    | Process name             | Process memory(MB)      |
+===========================+===============+====================================================+
| 0       0                 | 742173        |                          | 2855                    |
+===========================+===============+====================================================+
| 1       0                 | 742192        |                          | 26205                   |
+===========================+===============+====================================================+
| 2       0                 | 742144        |                          | 26205                   |

```
example:
```
[root@devserver-bms-163 dyy_epd_vllm_ascend epd]# bash disagg_xeypd_example.sh --model /workspace/models/Tarsier-34b --image-file-path /workspace/d00806799/code/epd/Jiusi-Script/run/cat.png 
Starting encoder workers...
  Encoder worker 0 starting on device 0, address: /tmp/encoder_0, log: /workspace/d00806799/code/epd/LM-service/examples/online_serving/epd/logs/encoder_0.log
Starting prefill/decode workers...
  Prefill/decode worker 0 starting on device 1, address: /tmp/prefill_decode_0, log: /workspace/d00806799/code/epd/LM-service/examples/online_serving/epd/logs/prefill_decode_0.log
All workers starting. PIDs are stored in /workspace/d00806799/code/epd/LM-service/examples/online_serving/epd/pid.txt.
INFO 12-08 12:02:02 [__init__.py:36] Available plugins for group vllm.platform_plugins:
INFO 12-08 12:02:02 [__init__.py:38] - ascend -> vllm_ascend:register
INFO 12-08 12:02:02 [__init__.py:41] All plugins in this group will be loaded. Set `VLLM_PLUGINS` to control which plugins to load.
INFO 12-08 12:02:02 [__init__.py:207] Platform plugin ascend is activated
INFO 12-08 12:02:05 [model.py:547] Resolved architecture: TarsierForConditionalGeneration
`torch_dtype` is deprecated! Use `dtype` instead!
INFO 12-08 12:02:05 [model.py:1510] Using max model len 4096
INFO 12-08 12:02:05 [proxy.py:307] Connected to worker ipc:///tmp/prefill_decode_0 success
INFO 12-08 12:02:05 [proxy.py:307] Connected to worker ipc:///tmp/encoder_0 success
INFO 12-08 12:02:21 [proxy.py:505] Connected to worker ipc:///tmp/encoder_0 success
INFO 12-08 12:02:24 [proxy.py:505] Connected to worker ipc:///tmp/prefill_decode_0 success
Request(0) generated_text: 西班
Request(0) generated_text: 西班MTY
Request(1) generated_text: nInstall
Request(2) generated_text: 回流
Request(3) generated_text: NDU
Request(4) generated_text: ++++++++
Request(5) generated_text: MTY
Request(6) generated_text: gressive
Request(7) generated_text: MDU
Request(8) generated_text: MTY
Request(9) generated_text: <h5>

```







## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

