### PR TITLE
[BugFix] qwen3 no load

### DIFF
--- a/vllm/model_executor/models/utils.py
+++ b/vllm/model_executor/models/utils.py
@@ -82,6 +82,25 @@ class WeightsMapper:
         }
 
 
+# Skip language model in Encoder instance
+def maybe_init_language_model(init_fn):
+    if has_ec_transfer() and get_ec_transfer().is_producer:
+        return None
+    return init_fn()
+
+
+# Skiped language model prefix
+def maybe_skip_language_model_prefix(
+    module: nn.Module,
+    skip_prefixes: list[str],
+    language_attr: str = "language_model",
+):
+    if (has_ec_transfer() and get_ec_transfer().is_producer
+            and hasattr(module, language_attr)
+            and getattr(module, language_attr) is None):
+        skip_prefixes.append(f"{language_attr}.")
+
+
 class AutoWeightsLoader:
     """
     Helper class to load weights into a [`torch.nn.Module`][]. It is able


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
Skip language model in encoder instance.
## Test Plan
mem usage is : 6104
```
+------------------------------------------------------------------------------------------------+
| npu-smi 24.1.rc2                 Version: 24.1.rc2                                             |
+---------------------------+---------------+----------------------------------------------------+
| NPU   Name                | Health        | Power(W)    Temp(C)           Hugepages-Usage(page)|
| Chip                      | Bus-Id        | AICore(%)   Memory-Usage(MB)  HBM-Usage(MB)        |
+===========================+===============+====================================================+
| 0     910B4               | OK            | 88.4        34                0    / 0             |
| 0                         | 0000:C1:00.0  | 0           0    / 0          6104 / 32768         |
+===========================+===============+====================================================+
| 1     910B4               | OK            | 87.4        36                0    / 0             |
| 0                         | 0000:01:00.0  | 0           0    / 0          18848/ 32768         |
+===========================+===============+====================================================+
| 2     910B4               | OK            | 89.3        36                0    / 0             |
| 0                         | 0000:C2:00.0  | 0           0    / 0          18653/ 32768         |
+===========================+===============+====================================================+
| 3     910B4               | OK            | 89.3        35                0    / 0             |
| 0                         | 0000:02:00.0  | 0           0    / 0          18653/ 32768         |
+===========================+===============+====================================================+
| 4     910B4               | OK            | 85.9        34                0    / 0             |
| 0                         | 0000:81:00.0  | 0           0    / 0          18656/ 32768         |
+===========================+===============+====================================================+
| 5     910B4               | OK            | 94.7        36                0    / 0             |
| 0                         | 0000:41:00.0  | 0           0    / 0          10652/ 32768         |
+===========================+===============+====================================================+
| 6     910B4               | OK            | 85.3        34                0    / 0             |
| 0                         | 0000:82:00.0  | 0           0    / 0          26110/ 32768         |
+===========================+===============+====================================================+
| 7     910B4               | OK            | 86.2        37                0    / 0             |
| 0                         | 0000:42:00.0  | 0           0    / 0          31018/ 32768         |

```

benchmark

???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
│ Performance Parameters   │ Stage   │ Average        │ Min            │ Max            │ Median         │ P75            │ P90            │ P99            │  N  │
???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
│ E2EL                     │ total   │ 142398.1001 ms │ 142398.1001 ms │ 142398.1001 ms │ 142398.1001 ms │ 142398.1001 ms │ 142398.1001 ms │ 142398.1001 ms │  1  │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TTFT                     │ total   │ 12677.6779 ms  │ 12677.6779 ms  │ 12677.6779 ms  │ 12677.6779 ms  │ 12677.6779 ms  │ 12677.6779 ms  │ 12677.6779 ms  │  1  │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TPOT                     │ total   │ 159.5577 ms    │ 159.5577 ms    │ 159.5577 ms    │ 159.5577 ms    │ 159.5577 ms    │ 159.5577 ms    │ 159.5577 ms    │  1  │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ ITL                      │ total   │ 159.2126 ms    │ 119.941 ms     │ 206.7609 ms    │ 157.3777 ms    │ 163.2802 ms    │ 169.3756 ms    │ 184.9083 ms    │  1  │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ InputTokens              │ total   │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 76.0           │  1  │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokens             │ total   │ 814.0          │ 814.0          │ 814.0          │ 814.0          │ 814.0          │ 814.0          │ 814.0          │  1  │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokenThroughput    │ total   │ 5.7164 token/s │ 5.7164 token/s │ 5.7164 token/s │ 5.7164 token/s │ 5.7164 token/s │ 5.7164 token/s │ 5.7164 token/s │  1  │
???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
???????????????????????????????????????????????????????
│ Common Metric            │ Stage   │ Value          │
???????????????????????????????????????????????????????
│ Benchmark Duration       │ total   │ 142398.1001 ms │
├──────────────────────────┼─────────┼────────────────┤
│ Total Requests           │ total   │ 1              │
├──────────────────────────┼─────────┼────────────────┤
│ Failed Requests          │ total   │ 0              │
├──────────────────────────┼─────────┼────────────────┤
│ Success Requests         │ total   │ 1              │
├──────────────────────────┼─────────┼────────────────┤
│ Concurrency              │ total   │ 1.0            │
├──────────────────────────┼─────────┼────────────────┤
│ Max Concurrency          │ total   │ 1024           │
├──────────────────────────┼─────────┼────────────────┤
│ Request Throughput       │ total   │ 0.007 req/s    │
├──────────────────────────┼─────────┼────────────────┤
│ Total Input Tokens       │ total   │ 76             │
├──────────────────────────┼─────────┼────────────────┤
│ Prefill Token Throughput │ total   │ 5.9948 token/s │
├──────────────────────────┼─────────┼────────────────┤
│ Total generated tokens   │ total   │ 814            │
├──────────────────────────┼─────────┼────────────────┤
│ Input Token Throughput   │ total   │ 0.5337 token/s │
├──────────────────────────┼─────────┼────────────────┤
│ Output Token Throughput  │ total   │ 5.7164 token/s │
├──────────────────────────┼─────────┼────────────────┤
│ Total Token Throughput   │ total   │ 6.2501 token/s │

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

