### PR TITLE
[Bugfix] update mm hash key with request id

### DIFF
--- a/vllm/distributed/ec_transfer/ec_connector/base.py
+++ b/vllm/distributed/ec_transfer/ec_connector/base.py
@@ -76,6 +76,20 @@ class ECConnectorBase(ABC):
     def is_producer(self) -> bool:
         return self._is_producer
 
+    def update_mm_hash_key(self, request: "Request"):
+        """Update the mm_hash key with request id"""
+        return None
+
+    def clean_caches(self, request: "Request") -> None:
+        """
+        Optional hook. clean caches in ec_consumer side when request is finish.
+
+        Args:
+            request: Request
+
+        """
+        return None
+
     # ==============================
     # Worker-side methods
     # ==============================

--- a/vllm/v1/core/sched/scheduler.py
+++ b/vllm/v1/core/sched/scheduler.py
@@ -1142,6 +1142,9 @@ class Scheduler(SchedulerInterface):
         return len(self.running), len(self.waiting)
 
     def add_request(self, request: Request) -> None:
+        if self.ec_connector is not None:
+            self.ec_connector.update_mm_hash_key(request)
+
         self.waiting.add_request(request)
         self.requests[request.request_id] = request
         if self.log_stats:
@@ -1203,6 +1206,9 @@ class Scheduler(SchedulerInterface):
 
         if not delay_free_blocks:
             self._free_blocks(request)
+
+        if self.ec_connector is not None:
+            self.ec_connector.clean_caches(request)
 
         return kv_xfer_params
 


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
（1） p0 -> p1 use mm_hash
  (2)  shedule & worker use request_id_mm_hash
 （3） skip embedding load/clear  when the same mm_hash in same request
## Test Plan
Benchmark
```
???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
│ Performance Parameters   │ Stage   │ Average        │ Min            │ Max            │ Median         │ P75            │ P90            │ P99            │  N  │
???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
│ E2EL                     │ total   │ 236109.6816 ms │ 101294.383 ms  │ 338611.1674 ms │ 236918.8513 ms │ 266103.6959 ms │ 299700.9674 ms │ 337113.3766 ms │ 270 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TTFT                     │ total   │ 69212.89 ms    │ 10625.1352 ms  │ 128432.6427 ms │ 68848.3112 ms  │ 98316.4424 ms  │ 113532.3364 ms │ 127065.3474 ms │ 270 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TPOT                     │ total   │ 314.4686 ms    │ 165.587 ms     │ 495.1572 ms    │ 315.7376 ms    │ 356.6456 ms    │ 413.9321 ms    │ 480.0825 ms    │ 270 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ ITL                      │ total   │ 289.8554 ms    │ 0.08 ms        │ 4718.9263 ms   │ 235.5667 ms    │ 254.7203 ms    │ 281.5076 ms    │ 2340.9193 ms   │ 270 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ InputTokens              │ total   │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 76.0           │ 270 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokens             │ total   │ 578.2556       │ 254.0          │ 1307.0         │ 508.0          │ 702.0          │ 1121.0         │ 1307.0         │ 270 │
├──────────────────────────┼─────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokenThroughput    │ total   │ 2.3417 token/s │ 1.3253 token/s │ 4.1731 token/s │ 2.2103 token/s │ 2.6506 token/s │ 3.501 token/s  │ 3.9829 token/s │ 270 │
???????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????????
?????????????????????????????????????????????????????????
│ Common Metric            │ Stage   │ Value            │
?????????????????????????????????????????????????????????
│ Benchmark Duration       │ total   │ 339576.7787 ms   │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Requests           │ total   │ 270              │
├──────────────────────────┼─────────┼──────────────────┤
│ Failed Requests          │ total   │ 0                │
├──────────────────────────┼─────────┼──────────────────┤
│ Success Requests         │ total   │ 270              │
├──────────────────────────┼─────────┼──────────────────┤
│ Concurrency              │ total   │ 187.7325         │
├──────────────────────────┼─────────┼──────────────────┤
│ Max Concurrency          │ total   │ 1024             │
├──────────────────────────┼─────────┼──────────────────┤
│ Request Throughput       │ total   │ 0.7951 req/s     │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Input Tokens       │ total   │ 20520            │
├──────────────────────────┼─────────┼──────────────────┤
│ Prefill Token Throughput │ total   │ 1.0981 token/s   │
├──────────────────────────┼─────────┼──────────────────┤
│ Total generated tokens   │ total   │ 156129           │
├──────────────────────────┼─────────┼──────────────────┤
│ Input Token Throughput   │ total   │ 60.4282 token/s  │
├──────────────────────────┼─────────┼──────────────────┤
│ Output Token Throughput  │ total   │ 459.7753 token/s │
├──────────────────────────┼─────────┼──────────────────┤
│ Total Token Throughput   │ total   │ 520.2034 token/s │
?????????????????????????????????????????????????????????

```

## Test Result

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

