### PR TITLE
[bugfix]fix load failed bug

### DIFF
--- a/vllm/distributed/ec_transfer/ec_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/ec_transfer/ec_lookup_buffer/mooncake_store.py
@@ -17,12 +17,11 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 import numpy as np
-import regex as re
 import torch
 
 from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.utils.tensor_memory_pool import (
-    InsufficientMemoryError, TensorMemoryPool)
+    TensorMemoryPool)
 from vllm.logger import init_logger
 
 DEFAULT_GLOBAL_SEGMENT_SIZE = 3355443200  # 3.125 GiB
@@ -175,6 +174,7 @@ class ECMooncakeStore:
 
         # Fast transfer init (Use zero-copy methods of mooncake)
         if self.config.fast_transfer:
+            self.pool_lock = threading.Lock()
             self.tensor_pool = TensorMemoryPool(
                 max_block_size=self.config.fast_transfer_buffer_size)
             self.store.register_buffer(self.tensor_pool.base_address,
@@ -239,7 +239,6 @@ class ECMooncakeStore:
             return [None] * len(keys)
 
         buffer_shapes = []
-        buffer_addrs = []
         buffer_dtypes = []
         sizes = []
         exist_ids = []
@@ -258,11 +257,13 @@ class ECMooncakeStore:
             num_elem = math.prod(buffer_shape)
             buffer_size = num_elem * element_size
 
-            buffer_addr = self._pool_allocate(buffer_size)
-            buffer_addrs.append(buffer_addr)
             buffer_dtypes.append(buffer_dtype)
             sizes.append(buffer_size)
             buffer_shapes.append(buffer_shape)
+        with self.pool_lock:
+            buffer_addrs = [
+                self.tensor_pool.allocate(buffer_size) for buffer_size in sizes
+            ]
 
         # Fill None first and
         # Replace valid keys with corresponding buffers.
@@ -272,6 +273,8 @@ class ECMooncakeStore:
             read_bytes = self.store.batch_get_into(valid_keys, buffer_addrs,
                                                    sizes)
         except Exception as e:
+            with self.pool_lock:
+                self.tensor_pool.batch_free(buffer_addrs)
             logger.error("batch_get_into failed: %s", str(e))
 
         # NOTE: should I delay free buffer
@@ -283,7 +286,8 @@ class ECMooncakeStore:
                 results[id] = self.tensor_pool.load_tensor(
                     addr, dtype, shape, device)
 
-            self.tensor_pool.free(addr)
+        with self.pool_lock:
+            self.tensor_pool.batch_free(buffer_addrs)
 
         return results
 
@@ -367,14 +371,13 @@ class ECMooncakeStore:
         meta_values = []
         buffer_addrs = []
         buffer_sizes = []
+        with self.pool_lock:
+            for key, tensor in zip(keys, tensors):
+                buffer_addr = self.tensor_pool.store_tensor(tensor)
+                buffer_size = tensor.numel() * tensor.element_size()
+                buffer_addrs.append(buffer_addr)
+                buffer_sizes.append(buffer_size)
         for key, tensor in zip(keys, tensors):
-            buffer_addr = self._pool_store_tensor(tensor)
-            self.fifo_pool_queue.append(
-                ECMooncakeTensorPoolMetadata(key, buffer_addr))
-            buffer_size = tensor.numel() * tensor.element_size()
-            buffer_addrs.append(buffer_addr)
-            buffer_sizes.append(buffer_size)
-
             meta = {"shape": list(tensor.shape), "dtype": str(tensor.dtype)}
             meta_str = json.dumps(meta)
             meta_bytes = meta_str.encode("utf-8")
@@ -414,6 +417,10 @@ class ECMooncakeStore:
                 ",".join(keys),
                 str(e),
             )
+        finally:
+            if buffer_addrs:
+                with self.pool_lock:
+                    self.tensor_pool.batch_free(buffer_addrs)
 
     async def _batch_put(self, keys: list[str],
                          tensors: list[torch.Tensor]) -> None:
@@ -454,36 +461,3 @@ class ECMooncakeStore:
                 ",".join(keys),
                 str(e),
             )
-
-    # ==============================
-    # Tensor pool helper functions
-    # ==============================
-
-    def _pool_eviction(self) -> None:
-        evicted_buffer = self.fifo_pool_queue.popleft()
-        self.tensor_pool.free(evicted_buffer.addr)
-        key = re.escape(evicted_buffer.key)
-        meta_key = re.escape(self.metadata_key(evicted_buffer.key))
-        count = self.store.remove_by_regex(f"^(?:{key}|{meta_key})$")
-        if count > 2:
-            logger.error("count of key and meta key exceeds 2")
-
-    def _pool_allocate(self, size: int) -> int:
-        while True:
-            try:
-                return self.tensor_pool.allocate(size)
-            except InsufficientMemoryError:
-                if not self.fifo_pool_queue:
-                    raise
-
-                self._pool_eviction()
-
-    def _pool_store_tensor(self, tensor: torch.Tensor) -> int:
-        while True:
-            try:
-                return self.tensor_pool.store_tensor(tensor)
-            except InsufficientMemoryError:
-                if not self.fifo_pool_queue:
-                    raise
-
-                self._pool_eviction()

--- a/vllm/distributed/ec_transfer/utils/tensor_memory_pool.py
+++ b/vllm/distributed/ec_transfer/utils/tensor_memory_pool.py
@@ -265,6 +265,10 @@ class TensorMemoryPool:
 
         return tensor
 
+    def batch_free(self, addrs: list[int]):
+        for addr in addrs:
+            self.free(addr)
+
     def cleanup(self):
         """Cleans up all memory resources and resets the pool state."""
         self.free_lists.clear()


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose

## Test Plan

## Test Result
image4 dataset
req rate: 1.28
```
╒══════════════════════════╤═════════╤═══════════════╤════════════════╤════════════════╤════════════════╤════════════════╤════════════════╤════════════════╤═════╕
│ Performance Parameters   │ Stage   │ Average       │ Min            │ Max            │ Median         │ P75            │ P90            │ P99            │  N  │
╞══════════════════════════╪═════════╪═══════════════╪════════════════╪════════════════╪════════════════╪════════════════╪════════════════╪════════════════╪═════╡
│ E2EL                     │ total   │ 77540.0921 ms │ 48108.7618 ms  │ 126103.292 ms  │ 68802.0891 ms  │ 92736.8303 ms  │ 114787.5189 ms │ 123617.3298 ms │ 200 │
├──────────────────────────┼─────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TTFT                     │ total   │ 59761.021 ms  │ 16626.3635 ms  │ 119402.5835 ms │ 55993.9361 ms  │ 82632.6508 ms  │ 103815.1257 ms │ 116197.5219 ms │ 200 │
├──────────────────────────┼─────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ TPOT                     │ total   │ 119.3226 ms   │ 44.9712 ms     │ 239.7662 ms    │ 83.7549 ms     │ 191.5488 ms    │ 204.0252 ms    │ 223.8153 ms    │ 200 │
├──────────────────────────┼─────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ ITL                      │ total   │ 122.8722 ms   │ 3.7121 ms      │ 7380.1733 ms   │ 53.3306 ms     │ 73.3269 ms     │ 152.565 ms     │ 1304.3316 ms   │ 200 │
├──────────────────────────┼─────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ InputTokens              │ total   │ 2021.0        │ 2021.0         │ 2021.0         │ 2021.0         │ 2021.0         │ 2021.0         │ 2021.0         │ 200 │
├──────────────────────────┼─────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokens             │ total   │ 150.0         │ 150.0          │ 150.0          │ 150.0          │ 150.0          │ 150.0          │ 150.0          │ 200 │
├──────────────────────────┼─────────┼───────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼────────────────┼─────┤
│ OutputTokenThroughput    │ total   │ 2.097 token/s │ 1.1895 token/s │ 3.1179 token/s │ 2.1802 token/s │ 2.5014 token/s │ 2.8633 token/s │ 3.063 token/s  │ 200 │
╘══════════════════════════╧═════════╧═══════════════╧════════════════╧════════════════╧════════════════╧════════════════╧════════════════╧════════════════╧═════╛
╒══════════════════════════╤═════════╤═══════════════════╕
│ Common Metric            │ Stage   │ Value             │
╞══════════════════════════╪═════════╪═══════════════════╡
│ Benchmark Duration       │ total   │ 209490.1888 ms    │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Requests           │ total   │ 200               │
├──────────────────────────┼─────────┼───────────────────┤
│ Failed Requests          │ total   │ 0                 │
├──────────────────────────┼─────────┼───────────────────┤
│ Success Requests         │ total   │ 200               │
├──────────────────────────┼─────────┼───────────────────┤
│ Concurrency              │ total   │ 74.0274           │
├──────────────────────────┼─────────┼───────────────────┤
│ Max Concurrency          │ total   │ 128               │
├──────────────────────────┼─────────┼───────────────────┤
│ Request Throughput       │ total   │ 0.9547 req/s      │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Input Tokens       │ total   │ 404200            │
├──────────────────────────┼─────────┼───────────────────┤
│ Prefill Token Throughput │ total   │ 33.818 token/s    │
├──────────────────────────┼─────────┼───────────────────┤
│ Total generated tokens   │ total   │ 30000             │
├──────────────────────────┼─────────┼───────────────────┤
│ Input Token Throughput   │ total   │ 1929.446 token/s  │
├──────────────────────────┼─────────┼───────────────────┤
│ Output Token Throughput  │ total   │ 143.2048 token/s  │
├──────────────────────────┼─────────┼───────────────────┤
│ Total Token Throughput   │ total   │ 2072.6508 token/s │
╘══════════════════════════╧═════════╧═══════════════════╛
```

---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

