### PR TITLE
adapt ascend direct transport

### DIFF
--- a/vllm/distributed/ec_transfer/ec_lookup_buffer/mooncake_store.py
+++ b/vllm/distributed/ec_transfer/ec_lookup_buffer/mooncake_store.py
@@ -22,7 +22,9 @@ import torch
 from vllm.config import VllmConfig
 from vllm.distributed.ec_transfer.utils.tensor_memory_pool import (
     TensorMemoryPool)
+from vllm.distributed.ec_transfer.utils.transfer_engine import get_global_te
 from vllm.logger import init_logger
+from vllm.utils import get_ip
 
 DEFAULT_GLOBAL_SEGMENT_SIZE = 3355443200  # 3.125 GiB
 DEFAULT_LOCAL_BUFFER_SIZE = 1073741824  # 1.0 GiB
@@ -148,15 +150,30 @@ class ECMooncakeStore:
             logger.info("  fast_transfer_buffer_size: %s",
                         self.config.fast_transfer_buffer_size)
 
-            self.store.setup(
-                self.config.local_hostname,
-                self.config.metadata_server,
-                self.config.global_segment_size,
-                self.config.local_buffer_size,
-                self.config.protocol,
-                self.config.device_name,
-                self.config.master_server_address,
-            )
+            if self.config.protocol == "ascend":
+                # if ascend direct transport is on,
+                # global transfer engine for an instance is required
+                local_hostname = get_ip()
+                transfer_engine = get_global_te(local_hostname,
+                                                device_name=None)
+                self.local_seg = local_hostname + ":" + str(
+                    transfer_engine.get_rpc_port())
+                self.store.setup(self.local_seg, "P2PHANDSHAKE",
+                                 self.config.global_segment_size,
+                                 self.config.local_buffer_size,
+                                 self.config.protocol, self.config.device_name,
+                                 self.config.master_server_address,
+                                 transfer_engine.get_engine())
+            else:
+                self.store.setup(
+                    self.config.local_hostname,
+                    self.config.metadata_server,
+                    self.config.global_segment_size,
+                    self.config.local_buffer_size,
+                    self.config.protocol,
+                    self.config.device_name,
+                    self.config.master_server_address,
+                )
 
         except ValueError as e:
             logger.error("Configuration loading failed: %s", e)
@@ -194,7 +211,8 @@ class ECMooncakeStore:
         if self.config.fast_transfer:
             self.store.unregister_buffer(self.tensor_pool.base_address,
                                          self.config.fast_transfer_buffer_size)
-            self.tensor_pool.cleanup()
+            with self.pool_lock:
+                self.tensor_pool.cleanup()
 
         self.put_loop.call_soon_threadsafe(self.put_loop.stop)
         self.put_thread.join()
@@ -276,6 +294,7 @@ class ECMooncakeStore:
             with self.pool_lock:
                 self.tensor_pool.batch_free(buffer_addrs)
             logger.error("batch_get_into failed: %s", str(e))
+            return results
 
         # NOTE: should I delay free buffer
         for id, addr, dtype, shape, read_byte in zip(exist_ids, buffer_addrs,
@@ -283,8 +302,9 @@ class ECMooncakeStore:
                                                      buffer_shapes,
                                                      read_bytes):
             if read_byte > 0:
-                results[id] = self.tensor_pool.load_tensor(
-                    addr, dtype, shape, device)
+                with self.pool_lock:
+                    results[id] = self.tensor_pool.load_tensor(
+                        addr, dtype, shape, device)
 
         with self.pool_lock:
             self.tensor_pool.batch_free(buffer_addrs)
@@ -398,6 +418,7 @@ class ECMooncakeStore:
                 ",".join(keys),
                 str(e),
             )
+            raise
 
         try:
             # Zero-copy put
@@ -417,6 +438,7 @@ class ECMooncakeStore:
                 ",".join(keys),
                 str(e),
             )
+            raise
         finally:
             if buffer_addrs:
                 with self.pool_lock:

--- a/vllm/distributed/ec_transfer/utils/transfer_engine.py
+++ b/vllm/distributed/ec_transfer/utils/transfer_engine.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+import ipaddress
+import threading
+from typing import Optional
+
+from mooncake.engine import TransferEngine  # type: ignore
+
+_global_te = None
+_global_te_lock = threading.Lock()
+
+
+def get_global_te(hostname: str, device_name: Optional[str]):
+    try:
+        ip = ipaddress.ip_address(hostname)
+        if isinstance(ip, ipaddress.IPv6Address):
+            raise RuntimeError(
+                "The backend of mooncake's Ascend Direct Xfer Library currently does not support IPv6."
+            )
+    except ValueError:
+        pass
+
+    global _global_te
+    if _global_te is None:
+        with _global_te_lock:
+            # Double-Checked Locking
+            if _global_te is None:
+                if TransferEngine is None:
+                    raise RuntimeError("mooncake is not available")
+                transfer_engine = TransferEngine()
+                device_name = device_name if device_name is not None else ""
+                ret_value = transfer_engine.initialize(hostname,
+                                                       "P2PHANDSHAKE",
+                                                       "ascend", device_name)
+                if ret_value != 0:
+                    raise RuntimeError(
+                        f"TransferEngine initialization failed with ret_value: {ret_value}"
+                    )
+                _global_te = transfer_engine
+    return _global_te

--- a/vllm/distributed/ec_transfer/utils/transfer_engine.py
+++ b/vllm/distributed/ec_transfer/utils/transfer_engine.py
@@ -16,8 +16,7 @@ def get_global_te(hostname: str, device_name: Optional[str]):
         if isinstance(ip, ipaddress.IPv6Address):
             raise RuntimeError(
                 "The backend of mooncake's Ascend Direct Xfer Library "
-                "currently does not support IPv6."
-            )
+                "currently does not support IPv6.")
     except ValueError:
         pass
 
@@ -36,7 +35,6 @@ def get_global_te(hostname: str, device_name: Optional[str]):
                 if ret_value != 0:
                     raise RuntimeError(
                         f"TransferEngine initialization failed with "
-                        f"ret_value: {ret_value}"
-                    )
+                        f"ret_value: {ret_value}")
                 _global_te = transfer_engine
     return _global_te

--- a/vllm/distributed/ec_transfer/utils/transfer_engine.py
+++ b/vllm/distributed/ec_transfer/utils/transfer_engine.py
@@ -15,7 +15,8 @@ def get_global_te(hostname: str, device_name: Optional[str]):
         ip = ipaddress.ip_address(hostname)
         if isinstance(ip, ipaddress.IPv6Address):
             raise RuntimeError(
-                "The backend of mooncake's Ascend Direct Xfer Library currently does not support IPv6."
+                "The backend of mooncake's Ascend Direct Xfer Library "
+                "currently does not support IPv6."
             )
     except ValueError:
         pass
@@ -34,7 +35,8 @@ def get_global_te(hostname: str, device_name: Optional[str]):
                                                        "ascend", device_name)
                 if ret_value != 0:
                     raise RuntimeError(
-                        f"TransferEngine initialization failed with ret_value: {ret_value}"
+                        f"TransferEngine initialization failed with "
+                        f"ret_value: {ret_value}"
                     )
                 _global_te = transfer_engine
     return _global_te


### PR DESCRIPTION
<!-- markdownlint-disable -->

## Purpose
adapt to ascend direct transport (-DUSE_ASCEND_DIRECT=ON when compile mooncake)
## Test Plan
D2D
D2H
## Test Result
D2D connector
curl:
```
[root@devserver-bms-165 cwj]# curl http://10.170.27.165:20009/v1/chat/completions -H "Content-Type: application/json" -d '{        "model": "/data/models/Qwen2.5-VL-7B-Instruct",        "messages": [
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": [
                {"type": "image_url", "image_url": {"url":"file:///workspace/w00613184/testvqa_val/train_images/40c6b4dd3caa006f.jpg"}},
                {"type": "text", "text": "how man price tags are on the bottom shelf?"}
            ]}
        ]
    }'
{"id":"chatcmpl-f28e10cd-a638-496a-a3cd-46cc8ef0a49c","object":"chat.completion","created":1766833895,"model":"/data/models/Qwen2.5-VL-7B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"There are six price tags on the bottom shelf of the image.","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":1400,"total_tokens":1414,"completion_tokens":14,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null,"metrics":null}
```
log: transfer success
```
(APIServer pid=194185) WARNING 12-27 19:11:28 [sampling_params.py:320] temperature 1e-06 is less than 0.01, which may cause numerical errors nan or inf in tensors. We have maxed it out to 0.01.
I20251227 19:11:33.971918 281455917789600 ascend_direct_transport.cpp:825] Connected to segment: 10.170.27.165:20748
I20251227 19:11:33.972998 281455917789600 ascend_direct_transport.cpp:605] Transfer to:10.170.27.165:20748, cost: 968 us
I20251227 19:11:34.031614 281455917789600 ascend_direct_transport.cpp:605] Transfer to:10.170.27.165:20748, cost: 1957 us
[rank0]:[W1227 19:11:34.254606751 compiler_depend.ts:117] Warning: Driver Version: 24.1.rc1.b020 is invalid or not supported yet. (function operator())
(EngineCore_DP0 pid=194631) INFO 12-27 19:11:34 [mooncake_connector.py:834] Delaying free of 11 blocks for request chatcmpl-f28e10cd-a638-496a-a3cd-46cc8ef0a49c
(APIServer pid=194185) INFO:     127.0.0.1:45882 - "POST /v1/chat/completions HTTP/1.1" 200 OK
(APIServer pid=194185) INFO 12-27 19:11:42 [loggers.py:127] Engine 000: Avg prompt throughput: 140.0 tokens/s, Avg generation throughput: 0.1 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=194185) INFO 12-27 19:11:52 [loggers.py:127] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 1.0%, Prefix cache hit rate: 0.0%
(APIServer pid=194185) WARNING 12-27 19:12:03 [sampling_params.py:320] temperature 1e-06 is less than 0.01, which may cause numerical errors nan or inf in tensors. We have maxed it out to 0.01.
I20251227 19:12:03.732793 281455917789600 ascend_direct_transport.cpp:605] Transfer to:10.170.27.165:20748, cost: 1181 us
I20251227 19:12:03.759117 281455917789600 ascend_direct_transport.cpp:605] Transfer to:10.170.27.165:20748, cost: 1880 us
(EngineCore_DP0 pid=194631) INFO 12-27 19:12:03 [mooncake_connector.py:834] Delaying free of 11 blocks for request chatcmpl-39508f53-95d5-4f37-b916-248ab8f969eb
(APIServer pid=194185) INFO:     127.0.0.1:40518 - "POST /v1/chat/completions HTTP/1.1" 200 OK

```
---
<details>
<summary> Essential Elements of an Effective PR Description Checklist </summary>

- [ ] The purpose of the PR, such as "Fix some issue (link existing issues this PR will resolve)".
- [ ] The test plan, such as providing test command.
- [ ] The test results, such as pasting the results comparison before and after, or e2e results
- [ ] (Optional) The necessary documentation update, such as updating `supported_models.md` and `examples` for a new model.
- [ ] (Optional) Release notes update. If your change is user facing, please update the release notes draft in the [Google Doc](https://docs.google.com/document/d/1YyVqrgX4gHTtrstbq8oWUImOyPCKSGnJ7xtTpmXzlRs/edit?tab=t.0).
</details>

D2H
```
curl http://10.170.27.165:20009/v1/chat/completions -H "Content-Type: application/json" -d '{        "model": "/data/models/Qwen2.5-VL-7B-Instruct",        "messages": [
            {"role": "system", "content": "You are a helpful assistant."},
            {"role": "user", "content": [
                {"type": "image_url", "image_url": {"url":"file:///workspace/w00613184/testvqa_val/train_images/40c6b4dd3caa006f.jpg"}},
                {"type": "text", "text": "how man price tags are on the bottom shelf?"}
            ]}
        ]
    }'
{"id":"chatcmpl-b1ee8ca8-cee0-49a7-b466-7fddbebb0b3d","object":"chat.completion","created":1766834770,"model":"/data/models/Qwen2.5-VL-7B-Instruct","choices":[{"index":0,"message":{"role":"assistant","content":"There are six price tags on the bottom shelf of the image.","refusal":null,"annotations":null,"audio":null,"function_call":null,"tool_calls":[],"reasoning_content":null},"logprobs":null,"finish_reason":"stop","stop_reason":null,"token_ids":null}],"service_tier":null,"system_fingerprint":null,"usage":{"prompt_tokens":1400,"total_tokens":1414,"completion_tokens":14,"prompt_tokens_details":null},"prompt_logprobs":null,"prompt_token_ids":null,"kv_transfer_params":null,"metrics":null}
```
log: transfer success
```
I20251227 19:25:22.415610 281457243058592 ascend_direct_transport.cpp:605] Transfer to:10.170.27.165:25522, cost: 878 us
I20251227 19:25:22.417544 281457243058592 ascend_direct_transport.cpp:605] Transfer to:10.170.27.165:25522, cost: 1906 us
(APIServer pid=201147) INFO 12-27 19:25:22 [loggers.py:127] Engine 000: Avg prompt throughput: 139.0 tokens/s, Avg generation throughput: 0.1 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
(APIServer pid=201147) INFO 12-27 19:25:32 [loggers.py:127] Engine 000: Avg prompt throughput: 0.0 tokens/s, Avg generation throughput: 0.0 tokens/s, Running: 0 reqs, Waiting: 0 reqs, GPU KV cache usage: 0.0%, Prefix cache hit rate: 0.0%
tail: inotify cannot be used, reverting to polling: Too many open files
(APIServer pid=201147) WARNING 12-27 19:26:09 [sampling_params.py:320] temperature 1e-06 is less than 0.01, which may cause numerical errors nan or inf in tensors. We have maxed it out to 0.01.
(APIServer pid=201147) INFO:     127.0.0.1:46304 - "POST /v1/chat/completions HTTP/1.1" 200 OK
I20251227 19:26:09.710890 281457243058592 ascend_direct_transport.cpp:605] Transfer to:10.170.27.165:25522, cost: 904 us
```